### PR TITLE
WIP: Add Product Hunt badge for launch day

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -41,6 +41,7 @@
             </span> 
           </span>
           <a href="https://github.com/diez/diez" target="_blank" class="hide-on-mobile" @click="sendGitHubClickEvent">Github</a>
+          <a href="https://www.producthunt.com/posts/haiku-animator?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-haiku-animator" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=147781&theme=dark" alt="Haiku Animator - Create powerful animations for any app or website | Product Hunt Embed" class="ph hide-on-mobile" width="192px" height="42px" /></a>
           <router-link class="button hide-on-mobile" to="/getting-started">Get started</router-link>
 
           <!-- Moble navigation -->
@@ -223,5 +224,10 @@ export default {
     top: $mobile-toggle-margin;
     right: $mobile-toggle-margin;
     cursor: pointer;
+  }
+  
+  .ph {
+    width: 192px;
+    height: 42px;
   }
 </style>


### PR DESCRIPTION
I've added a Product Hunt badge to our navigation bar for launch day.

![image](https://user-images.githubusercontent.com/1357566/68978119-859c9180-07bf-11ea-8d89-03a1be2129af.png)

**Note that this is the wrong link!** We'll need to get the real link after creating the new Product Hunt post. You can do this by going to the post page and then choosing the "embed" option shown below the post image:

![image](https://user-images.githubusercontent.com/1357566/68978211-c0062e80-07bf-11ea-80a0-35af86044b6d.png)

**A couple important details when replacing the placeholder embed code in the `NavBar.vue`**:
* Be sure to choose the "Dark" mode.
* Remove the embed code's `style="width: 192px; height: 42px;"` and replace it with `class="ph hide-on-mobile".
